### PR TITLE
feat(GetDocumentsForPerson): add new endpoint and associated caching/Civica calls

### DIFF
--- a/src/Controllers/PeopleController.cs
+++ b/src/Controllers/PeopleController.cs
@@ -1,9 +1,11 @@
-﻿using System.ComponentModel.DataAnnotations;
+﻿using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
 using revs_bens_service.Services.Benefits;
 using revs_bens_service.Services.CouncilTax;
 using StockportGovUK.AspNetCore.Attributes.TokenAuthentication;
+using StockportGovUK.NetStandard.Models.RevsAndBens;
 
 namespace revs_bens_service.Controllers
 {
@@ -76,6 +78,17 @@ namespace revs_bens_service.Controllers
                 return NoContent();
             
             return File(document, "application/pdf", "download.pdf");
+        }
+
+        [HttpGet]
+        [Route("{personReference}/council-tax/documents")]
+        public async Task<IActionResult> GetDocumentsForPerson([FromRoute][Required] string personReference) {
+            IEnumerable<CouncilTaxDocument> documents = await _councilTaxService.GetDocumentsForPerson(personReference);
+
+            if (documents == null)
+                return NotFound();
+
+            return Ok(documents);
         }
     }
 }

--- a/src/Controllers/PeopleController.cs
+++ b/src/Controllers/PeopleController.cs
@@ -82,10 +82,11 @@ namespace revs_bens_service.Controllers
 
         [HttpGet]
         [Route("{personReference}/council-tax/documents")]
-        public async Task<IActionResult> GetDocumentsForPerson([FromRoute][Required] string personReference) {
-            IEnumerable<CouncilTaxDocument> documents = await _councilTaxService.GetDocumentsForPerson(personReference);
+        public async Task<IActionResult> GetDocumentsForPerson([FromRoute][Required] string personReference) 
+        {
+            List<CouncilTaxDocument> documents = await _councilTaxService.GetDocumentsForPerson(personReference);
 
-            if (documents == null)
+            if (documents is null)
                 return NotFound();
 
             return Ok(documents);

--- a/src/Services/CouncilTax/CouncilTaxService.cs
+++ b/src/Services/CouncilTax/CouncilTaxService.cs
@@ -5,7 +5,6 @@ using System.Net;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
 using revs_bens_service.Services.Benefits;
-using revs_bens_service.Services.Benefits.Mappers;
 using revs_bens_service.Services.CouncilTax.Mappers;
 using revs_bens_service.Utils.Parsers;
 using revs_bens_service.Utils.StorageProvider;
@@ -23,13 +22,15 @@ namespace revs_bens_service.Services.CouncilTax
         private readonly IBenefitsService _benefitsService;
         private readonly string _current = "CURRENT";
 
-        public CouncilTaxService(ICivicaServiceGateway gateway, ICacheProvider cacheProvider, IBenefitsService benefitsService) {
+        public CouncilTaxService(ICivicaServiceGateway gateway, ICacheProvider cacheProvider, IBenefitsService benefitsService)
+        {
             _gateway = gateway;
             _cacheProvider = cacheProvider;
             _benefitsService = benefitsService;
         }
 
-        public async Task<CouncilTaxDetailsModel> GetBaseCouncilTaxAccount(string personReference) {
+        public async Task<CouncilTaxDetailsModel> GetBaseCouncilTaxAccount(string personReference)
+        {
             var key = $"{personReference}-{DateTime.Now.Year}-{CacheKeys.CouncilTaxDetails}";
             var cacheResponse = await _cacheProvider.GetStringAsync(key);
 
@@ -50,7 +51,8 @@ namespace revs_bens_service.Services.CouncilTax
             return model;
         }
 
-        public async Task<List<CouncilTaxAccountDetails>> GetCouncilTaxAccounts(string personReference) {
+        public async Task<List<CouncilTaxAccountDetails>> GetCouncilTaxAccounts(string personReference)
+        {
             var key = $"{personReference}-{DateTime.Now.Year}-{CacheKeys.CouncilTaxAccounts}";
             var cacheResponse = await _cacheProvider.GetStringAsync(key);
 
@@ -65,7 +67,8 @@ namespace revs_bens_service.Services.CouncilTax
             return model.Accounts.ToList();
         }
 
-        public async Task<string> GetCurrentCouncilTaxAccountNumber(string personReference) {
+        public async Task<string> GetCurrentCouncilTaxAccountNumber(string personReference)
+        {
             var accounts = await GetCouncilTaxAccounts(personReference);
 
             if (!accounts.Any())
@@ -78,7 +81,8 @@ namespace revs_bens_service.Services.CouncilTax
             return reference;
         }
 
-        public async Task<CouncilTaxDetailsModel> GetReducedCouncilTaxDetails(string personReference, string accountReference, int year) {
+        public async Task<CouncilTaxDetailsModel> GetReducedCouncilTaxDetails(string personReference, string accountReference, int year)
+        {
             var trimmedAccountReference = accountReference.Trim();
             var key = $"{personReference}-{trimmedAccountReference}-{year}-{CacheKeys.ReducedCouncilTaxDetails}";
             var cacheResponse = await _cacheProvider.GetStringAsync(key);
@@ -107,7 +111,8 @@ namespace revs_bens_service.Services.CouncilTax
             return model;
         }
 
-        public async Task<CouncilTaxDetailsModel> GetCouncilTaxDetails(string personReference, string accountReference, int year) {
+        public async Task<CouncilTaxDetailsModel> GetCouncilTaxDetails(string personReference, string accountReference, int year)
+        {
             var trimmedAccountReference = accountReference.Trim();
             var key = $"{personReference}-{trimmedAccountReference}-{year}-{CacheKeys.CouncilTaxDetails}";
             var cacheResponse = await _cacheProvider.GetStringAsync(key);
@@ -141,7 +146,8 @@ namespace revs_bens_service.Services.CouncilTax
             return model;
         }
 
-        public async Task<byte[]> GetDocumentForAccount(string personReference, string accountReference, string documentId) {
+        public async Task<byte[]> GetDocumentForAccount(string personReference, string accountReference, string documentId)
+        {
             var trimmedAccountReference = accountReference.Trim();
             var key = $"{personReference}-{trimmedAccountReference}-{documentId}-{CacheKeys.CouncilTaxDetails}";
             var cacheResponse = await _cacheProvider.GetStringAsync(key);
@@ -161,7 +167,8 @@ namespace revs_bens_service.Services.CouncilTax
             return document;
         }
 
-        public async Task<List<CouncilTaxDocument>> GetDocumentsForPerson(string personReference) {
+        public async Task<List<CouncilTaxDocument>> GetDocumentsForPerson(string personReference)
+        {
             var key = $"{personReference}-{CacheKeys.Documents}";
 
             var cacheResponse = await _cacheProvider.GetStringAsync(key);

--- a/src/Services/CouncilTax/ICouncilTaxService.cs
+++ b/src/Services/CouncilTax/ICouncilTaxService.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using StockportGovUK.NetStandard.Models.RevsAndBens;
 using System.Threading.Tasks;
+using StockportGovUK.NetStandard.Models.Civica.CouncilTax;
 
 namespace revs_bens_service.Services.CouncilTax
 {
@@ -17,5 +18,7 @@ namespace revs_bens_service.Services.CouncilTax
         Task<CouncilTaxDetailsModel> GetCouncilTaxDetails(string personReference, string accountReference, int year);
 
         Task<byte[]> GetDocumentForAccount(string personReference, string accountReference, string documentId);
+
+        Task<IEnumerable<CouncilTaxDocument>> GetDocumentsForPerson(string personReference);
     }
 }

--- a/src/Services/CouncilTax/ICouncilTaxService.cs
+++ b/src/Services/CouncilTax/ICouncilTaxService.cs
@@ -19,6 +19,6 @@ namespace revs_bens_service.Services.CouncilTax
 
         Task<byte[]> GetDocumentForAccount(string personReference, string accountReference, string documentId);
 
-        Task<IEnumerable<CouncilTaxDocument>> GetDocumentsForPerson(string personReference);
+        Task<List<CouncilTaxDocument>> GetDocumentsForPerson(string personReference);
     }
 }

--- a/src/Services/CouncilTax/Mappers/DocumentMapper.cs
+++ b/src/Services/CouncilTax/Mappers/DocumentMapper.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
-using StockportGovUK.NetStandard.Models.Civica.CouncilTax;
 using StockportGovUK.NetStandard.Models.RevsAndBens;
 using CouncilTaxDetailsModel = StockportGovUK.NetStandard.Models.RevsAndBens.CouncilTaxDetailsModel;
 
@@ -11,21 +10,13 @@ namespace revs_bens_service.Services.CouncilTax.Mappers
     public static class DocumentMapper
     {
         public static CouncilTaxDetailsModel DocumentsMapper(
-            this List<CouncilTaxDocumentReference> documentResponse,
+            this List<CouncilTaxDocument> documentResponse,
             CouncilTaxDetailsModel model,
             int taxYear)
         {
             model.Documents = documentResponse
                 .Where(_ => _.AccountReference == model.Reference)
-                .Select(_ => new CouncilTaxDocument
-                {
-                    AccountReference = _.AccountReference,
-                    DateCreated = _.DateCreated,
-                    DocumentId = _.DocumentId,
-                    DocumentName = _.DocumentName,
-                    DocumentType = _.DocumentType,
-                    Downloaded = _.Downloaded
-                }).ToList();
+                .ToList();
             
             if(model.Documents != null )
             {

--- a/src/Utils/StorageProvider/CacheKeysEnum.cs
+++ b/src/Utils/StorageProvider/CacheKeysEnum.cs
@@ -6,6 +6,7 @@ namespace revs_bens_service.Utils.StorageProvider
         CouncilTaxDetails,
         HasBenefits,
         ReducedCouncilTaxDetails,
-        CouncilTaxAccounts
+        CouncilTaxAccounts,
+        Documents
     }
 }

--- a/src/revs-bens-service.csproj
+++ b/src/revs-bens-service.csproj
@@ -20,7 +20,7 @@
     <PackageReference Include="StockportGovUK.AspNetCore.Attributes.TokenAuthentication" Version="1.0.0" />
     <PackageReference Include="StockportGovUK.AspNetCore.Availability" Version="1.1.0" />
     <PackageReference Include="StockportGovUK.AspNetCore.Logging.Elasticsearch.Aws" Version="1.0.0" />
-    <PackageReference Include="StockportGovUK.NetStandard.Gateways" Version="8.7.0" />
+    <PackageReference Include="StockportGovUK.NetStandard.Gateways" Version="9.2.2-prerelease-142" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="5.6.3" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
     <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />

--- a/tests/Controller/PeopleControllerTests.cs
+++ b/tests/Controller/PeopleControllerTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading.Tasks;
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
 using Moq;
 using revs_bens_service.Controllers;
@@ -28,6 +29,10 @@ namespace revs_bens_service_tests.Controller
             _mockCouncilTaxService
                 .Setup(_ => _.GetDocumentForAccount(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
                 .ReturnsAsync(new byte[1]);
+
+            _mockCouncilTaxService
+                .Setup(_ => _.GetDocumentsForPerson(It.IsAny<string>()))
+                .ReturnsAsync(new List<CouncilTaxDocument>());
 
             _mockCouncilTaxService
                 .Setup(_ => _.GetCouncilTaxDetails(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>()))
@@ -197,6 +202,41 @@ namespace revs_bens_service_tests.Controller
 
             // Assert
             Assert.IsType<FileContentResult>(result);
+        }
+
+        [Fact]
+        public async Task GetDocumentsForPerson_ShouldCallCouncilTaxService()
+        {
+            // Act
+            await _controller.GetDocumentsForPerson("personReference");
+
+            // Assert
+            _mockCouncilTaxService.Verify(_ => _.GetDocumentsForPerson(It.IsAny<string>()), Times.Once);
+        }
+
+        [Fact]
+        public async Task GetDocumentsForPerson_ShouldReturnNotFound_IfNullResponse()
+        {
+            // Arrange
+            _mockCouncilTaxService
+                .Setup(_ => _.GetDocumentsForPerson(It.IsAny<string>()))
+                .ReturnsAsync((List<CouncilTaxDocument>) null);
+
+            // Act
+            var result = await _controller.GetDocumentsForPerson("personReference");
+
+            // Assert
+            Assert.IsType<NotFoundResult>(result);
+        }
+
+        [Fact]
+        public async Task GetDocumentsForPerson_ShouldReturnOk()
+        {
+            // Act
+            var result = await _controller.GetDocumentsForPerson("personReference");
+
+            // Assert
+            Assert.IsType<OkObjectResult>(result);
         }
     }
 }


### PR DESCRIPTION
Have replaced CouncilTaxDocumentResponse with CouncilTaxDocument as the models were identical and it seemed pointless to waste lines of code mapping an identical model